### PR TITLE
Apply shared login background

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <nav class="navbar navbar-expand-lg navbar-light bg-light admin-navbar">
           <div class="container-fluid">

--- a/templates/admin_detalle.html
+++ b/templates/admin_detalle.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="ponderacion-container">
             <h3>Asignar Ponderación – Respuesta #{{ respuesta.id_respuesta }}</h3>

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="admin-container">
             <div class="logo-container">

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="admin-container">
             <div class="logo-container">

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
   <div class="container py-5">
     <div id="rankingContent">
       <div class="logo-container">

--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="confirmation-card">
             <!-- Logos -->

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="admin-container text-center">
             <div class="logo-container">

--- a/templates/error_400.html
+++ b/templates/error_400.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="confirmation-card">
             <div class="check-icon">

--- a/templates/error_404.html
+++ b/templates/error_404.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="confirmation-card">
             <div class="check-icon">

--- a/templates/error_500.html
+++ b/templates/error_500.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="confirmation-card">
             <div class="check-icon">

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -41,7 +41,7 @@
     </script>
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="evaluation-card">
             <!-- Espacio para los 3 logos -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,29 +9,9 @@
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
-    <style>
-        body {
-            background: url("{{ url_for('static', filename='img/background.png') }}") no-repeat center center fixed;
-            background-size: cover;
-        }
-
-        .login-card {
-            background-color: white;
-            /* Fondo blanco */
-            border-radius: 10px;
-            /* Bordes redondeados para mejor apariencia */
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-            /* Sombra para mejor contraste */
-        }
-
-        .card-header {
-            background-color: #343a40;
-            /* Manteniendo el color oscuro del header */
-        }
-    </style>
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="login-card mx-auto">
             <div class="card-header">


### PR DESCRIPTION
## Summary
- Remove inline background styling from index template and apply reusable `login-background` class.
- Add `login-background` class to body in admin, user, and error templates so all pages share the same background image.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689655c4c404832290e69f9dad1139d5