### PR TITLE
Eliminar logos de vistas adicionales

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -30,19 +30,6 @@
           </div>
         </nav>
         <div class="admin-container">
-            <!-- Espacio para los 3 logos -->
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-
             <h2>Panel del Administrador</h2>
 
             {% if respuestas %}

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -13,18 +13,6 @@
 <body class="login-background">
     <div class="container py-5">
         <div class="admin-container">
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-
             <h2>Editar Factores</h2>
 
             <form method="POST" action="{{ url_for('administrar_factores') }}">

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -13,18 +13,6 @@
 <body class="login-background">
     <div class="container py-5">
         <div class="admin-container">
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-
             <h2>Administrar Formularios</h2>
 
             {% if formularios %}

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -17,18 +17,6 @@
 <body class="login-background">
   <div class="container py-5">
     <div id="rankingContent">
-      <div class="logo-container">
-        <div class="logo-img-container">
-          <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-        </div>
-        <div class="logo-img-container">
-          <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-        </div>
-        <div class="logo-img-container">
-          <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-        </div>
-      </div>
-
       <h3>Ranking Global de Factores</h3>
 
       {% if pendientes %}

--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -11,19 +11,6 @@
 <body class="login-background">
     <div class="container py-5">
         <div class="confirmation-card">
-            <!-- Logos -->
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-            
             <!-- Icono de confirmación -->
             <div class="check-icon">
                 <i class="bi bi-check-lg"></i>

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -13,18 +13,6 @@
 <body class="login-background">
     <div class="container py-5">
         <div class="admin-container text-center">
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-
             <h2>Confirmar eliminación</h2>
             <p>Se encontraron {{ respuestas }} respuestas asociadas a este formulario.
                 ¿Deseas eliminarlo de todos modos?</p>

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -44,19 +44,6 @@
 <body class="login-background">
     <div class="container py-5">
         <div class="evaluation-card">
-            <!-- Espacio para los 3 logos -->
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-            
             <h2>Formulario de Evaluación Multicriterio</h2>
 
             {% with messages = get_flashed_messages() %}


### PR DESCRIPTION
## Summary
- remueve los bloques de logos de las vistas de formularios, confirmaciones y secciones del admin
- mantiene los logos solo en `index.html` y en el login del administrador

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896595f7d788322ad2d90343afddae6